### PR TITLE
fix: support cn in vivo os (close: #30)

### DIFF
--- a/app/src/main/java/android/content/IClipboard.java
+++ b/app/src/main/java/android/content/IClipboard.java
@@ -22,6 +22,9 @@ public interface IClipboard {
     @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     ClipData getPrimaryClip(String pkg, String attributionTag, int userId, int deviceId, String targetPackage);
 
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    ClipData getPrimaryClip(String pkg, String attributionTag, String var1, String var2 ,int userId, int deviceId, boolean isUserOperation);
+
     void setPrimaryClip(ClipData clip, String callingPackage);
 
     @TargetApi(Build.VERSION_CODES.Q)
@@ -34,6 +37,9 @@ public interface IClipboard {
     void setPrimaryClip(ClipData clip, String callingPackage, String attributionTag, int userId,
                         int deviceId);
 
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    void setPrimaryClip(ClipData clip, String callingPackage, String attributionTag, int userId,
+                        int deviceId, boolean isUserOperation);
     @YRouterSystem
     class Stub {
         public static IClipboard asInterface(IBinder obj) {

--- a/app/src/main/java/com/ysbing/yadb/input/ClipboardManager.java
+++ b/app/src/main/java/com/ysbing/yadb/input/ClipboardManager.java
@@ -28,7 +28,11 @@ public class ClipboardManager {
             try {
                 return manager.getPrimaryClip(Main.PACKAGE_NAME, null, Main.USER_ID, 0);
             } catch (NoSuchMethodError e) {
-                return manager.getPrimaryClip(Main.PACKAGE_NAME, null, Main.USER_ID, 0, null);
+                try {
+                    return manager.getPrimaryClip(Main.PACKAGE_NAME, null, Main.USER_ID, 0, null);
+                } catch (NoSuchMethodError error) {
+                    return manager.getPrimaryClip(Main.PACKAGE_NAME, null, null, null, Main.USER_ID, 0, false);
+                }
             }
         }
     }
@@ -45,7 +49,11 @@ public class ClipboardManager {
                 manager.setPrimaryClip(clipData, Main.PACKAGE_NAME, Main.USER_ID);
             }
         } else {
-            manager.setPrimaryClip(clipData, Main.PACKAGE_NAME, null, Main.USER_ID, 0);
+            try {
+                manager.setPrimaryClip(clipData, Main.PACKAGE_NAME, null, Main.USER_ID, 0);
+            } catch (NoSuchMethodError e) {
+                manager.setPrimaryClip(clipData, Main.PACKAGE_NAME, null, Main.USER_ID, 0, false);
+            }
         }
     }
 


### PR DESCRIPTION
The NoSuchMethodException error occurred on the iQOO 12 Pro device. After decompiling the framework.jar file from the device, we identified that the method signature differed from the expected definition. Through compatibility adjustments and verification, the issue has been successfully resolved.

![image](https://github.com/user-attachments/assets/3388102b-fa01-48cf-aece-c0a6a462c71a)

